### PR TITLE
Update version of Crashplan to 3.5.3

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 
 class crashplan {
   package { 'Crashplan':
-    source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.4.1_Mac.dmg',
+    source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.5.3_Mac.dmg',
     provider => pkgdmg,
   }
 }


### PR DESCRIPTION
The earlier version isn't compatible with Java 1.7, but this version is.
