### PR TITLE
Update CrashPlan version to 3.5.3

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 
 class crashplan {
   package { 'Crashplan':
-    source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.4.1_Mac.dmg',
+    source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.5.3_Mac.dmg',
     provider => pkgdmg,
   }
 }

--- a/spec/classes/crashplan_spec.rb
+++ b/spec/classes/crashplan_spec.rb
@@ -4,7 +4,7 @@ describe 'Crashplan' do
   it do
     should contain_package('Crashplan').with({
       :provider => 'pkgdmg',
-      :source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.4.1_Mac.dmg',
+      :source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.5.3_Mac.dmg',
     })
   end
 end


### PR DESCRIPTION
Earlier versions were incompatible (only supporting Java v6) with
Boxen's Java module which installs Java v7
