### PR TITLE
Update link: CrashPlan 3.6.3

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 
 class crashplan {
   package { 'Crashplan':
-    source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.5.3_Mac.dmg',
+    source   => 'http://download.code42.com/installs/mac/install/CrashPlan/CrashPlan_3.6.3_Mac.dmg',
     provider => pkgdmg,
   }
 }


### PR DESCRIPTION
Landing page: http://www.code42.com/crashplan/thankyou/?os=mac

Update link so we download CrashPlan 3.6.3. 
