### PR TITLE
add version class param and bump minor version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,9 +4,11 @@
 #
 #   include crashplan
 
-class crashplan {
+class crashplan (
+  $version = '3.6.3',
+) {
   package { 'Crashplan':
-    source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.5.3_Mac.dmg',
-    provider => pkgdmg,
+    source   => "http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_${version}_Mac.dmg",
+    provider => 'pkgdmg',
   }
 }

--- a/spec/classes/crashplan_spec.rb
+++ b/spec/classes/crashplan_spec.rb
@@ -4,7 +4,7 @@ describe 'Crashplan' do
   it do
     should contain_package('Crashplan').with({
       :provider => 'pkgdmg',
-      :source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.5.3_Mac.dmg',
+      :source   => 'http://download.crashplan.com/installs/mac/install/CrashPlan/CrashPlan_3.6.3_Mac.dmg',
     })
   end
 end


### PR DESCRIPTION
This will allow the version of the crashplan desktop application to be specified when declaring the crashplan class.  I also bumped the default version to the current release.
